### PR TITLE
fixed issue 21. Sometimes, thrown exception messages are obfuscated by the exception handler

### DIFF
--- a/bin/expresso
+++ b/bin/expresso
@@ -696,7 +696,7 @@ function watchFiles(files) {
 function error(suite, test, err) {
     ++failures;
     var name = err.name,
-        stack = err.stack.replace(err.name, ''),
+        stack = (err.stack ? err.stack.replace(err.name, '') : 'sorry, no stack trace'),
         label = test === 'uncaught'
             ? test
             : suite + ' ' + test;

--- a/test/dont_obscure_error_message.test.js
+++ b/test/dont_obscure_error_message.test.js
@@ -1,0 +1,14 @@
+sys = require ('sys')
+
+function stack_overflow(){
+	return stack_overflow();
+}
+
+exports.test_stackoverflow_error = function(assert){
+	try {
+		stack_overflow();
+	} catch (e){
+		assert.equal('RangeError',e.name);
+		//some errors have no stack trace, which was causing a TypeError on at line 699 in ../bin/expresso
+	}
+}


### PR DESCRIPTION
some error message have no stack trace. 

for example, stack overflow.

created one line fix where i check that err.stack is defined, and created test to check fix.

cheers. Dominic
