### PR TITLE
updated install instructions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -25,6 +25,8 @@
 
 To install both expresso _and_ node-jscoverage run:
 
+    $ git submodule init
+    $ git submodule update
     $ make install
 
 To install expresso alone (no build required) run:


### PR DESCRIPTION
I updated the install instructions to include the steps for initializing and updating the submodules (using git). This seemed to be required to install jscoverage.
