### PR TITLE
Pass test name to setup method

### DIFF
--- a/bin/expresso
+++ b/bin/expresso
@@ -1,6 +1,12 @@
 #!/usr/bin/env node
 
 /*
+ * A namespaced shim that allows me to run modules in both the browser and Node.
+ * See http://www.sitepen.com/blog/2010/09/30/run-anywhere-javascript-modules-boilerplate-code/
+ */
+ZC_DEFINE = typeof(define) == 'undefined';
+
+/*
  * Expresso
  * Copyright(c) TJ Holowaychuk <tj@vision-media.ca>
  * (MIT Licensed)


### PR DESCRIPTION
This is obviously a very minor convenience.

I run all my func tests serially. Passing the test name to setup allows me to set a key in redis, so I can easily see what calls are related to a given test.
