### PR TITLE
Make sure err.stack is there when calling replace

### DIFF
--- a/bin/expresso
+++ b/bin/expresso
@@ -711,7 +711,7 @@ function runFile(file, fn) {
 function error(suite, test, err) {
     ++failures;
     var name = err.name,
-        stack = err.stack.replace(err.name, ''),
+        stack = err.stack ? err.stack.replace(err.name, '') : '',
         label = test === 'uncaught'
             ? test
             : suite + ' ' + test;


### PR DESCRIPTION
In the case of a "stack overflow" or RangeError, your error handler tries to call replace on err.stack. That is non-existent on these types if errors. It makes it really hard to track down the issue when all you see is this:

uncaught: TypeError: Cannot call method 'replace' of undefined
    at error (/usr/local/lib/node/.npm/expresso/0.7.2/package/bin/expresso:715:27)
    at next (/usr/local/lib/node/.npm/expresso/0.7.2/package/bin/expresso:782:21)
    at next (/usr/local/lib/node/.npm/expresso/0.7.2/package/bin/expresso:785:26)
    at runSuite (/usr/local/lib/node/.npm/expresso/0.7.2/package/bin/expresso:789:6)
    at check (/usr/local/lib/node/.npm/expresso/0.7.2/package/bin/expresso:695:16)
    at runFile (/usr/local/lib/node/.npm/expresso/0.7.2/package/bin/expresso:699:10)
    at Array.forEach (native)
    at runFiles (/usr/local/lib/node/.npm/expresso/0.7.2/package/bin/expresso:676:13)
    at run (/usr/local/lib/node/.npm/expresso/0.7.2/package/bin/expresso:645:5)
    at Object.<anonymous> (/usr/local/lib/node/.npm/expresso/0.7.2/package/bin/expresso:857:13)

   Failures: 2
