### PR TITLE
Reverse output order

### DIFF
--- a/bin/expresso
+++ b/bin/expresso
@@ -505,6 +505,17 @@ function rpad(str, width) {
  */
 
 function reportCoverage(cov) {
+    // Source
+    for (var name in cov) {
+        if (name.match(/\.js$/)) {
+            var file = cov[name];
+            if ((file.coverage < 100) || !quiet) {
+               print('\n   [bold]{' + name + '}:'); 
+               print(file.source);
+               sys.print('\n');
+            }
+        }
+    }
     // Stats
     print('\n   [bold]{Test Coverage}\n');
     var sep = '   +------------------------------------------+----------+------+------+--------+',
@@ -531,17 +542,6 @@ function reportCoverage(cov) {
     sys.print(' | ' + lpad(cov.totalMisses, 6));
     sys.print(' |\n');
     sys.puts(lastSep);
-    // Source
-    for (var name in cov) {
-        if (name.match(/\.js$/)) {
-            var file = cov[name];
-            if ((file.coverage < 100) || !quiet) {
-               print('\n   [bold]{' + name + '}:'); 
-               print(file.source);
-               sys.print('\n');
-            }
-        }
-    }
 }
 
 /**
@@ -795,6 +795,12 @@ function runSuite(title, tests, fn) {
 function report() {
     cursor(true);
     process.emit('beforeExit');
+    if (typeof _$jscoverage === 'object') {
+        populateCoverage(_$jscoverage);
+        if (!hasFullCoverage(_$jscoverage) || !quiet) {
+            reportCoverage(_$jscoverage);
+        }
+    }
     if (failures) {
         print('\n   [bold]{Failures}: [red]{' + failures + '}\n\n');
         notify('Failures: ' + failures);
@@ -802,12 +808,6 @@ function report() {
         if (serial) print('');
         print('\n   [green]{100%} ' + testcount + ' tests\n');
         notify('100% ok');
-    }
-    if (typeof _$jscoverage === 'object') {
-        populateCoverage(_$jscoverage);
-        if (!hasFullCoverage(_$jscoverage) || !quiet) {
-            reportCoverage(_$jscoverage);
-        }
     }
 }
 


### PR DESCRIPTION
Once I got coverage reporting working, my first reaction was that the output was in the wrong order; I need to scroll back pages to find out if all my tests passed and how good my coverage actually is. This pull request is to reverse the order of output, so the annotated source is output first, followed by the coverage summary, followed by the test result summary. 

I haven't looked at making test failure output come after the coverage reporting as (a) I suspect it isn't buffered, on account of (b) i suspect it would be bad to buffer it for a large test suite with lots of failures ;-) and (c) I can run without -c when I want to see that information.

Next on the todo list would be to provide an option to output the coverage summary without the coverage detail, perhaps making that the default with -c (in other words, add options to turn on/off coverage detail reporting and, given that option, perhaps turn it off by default).
