### PR TITLE
Also obey the quiet param when not running jscoverage

### DIFF
--- a/bin/expresso
+++ b/bin/expresso
@@ -652,10 +652,12 @@ function run(files) {
  */
 
 function cursor(show) {
-    if (show) {
-        sys.print('\x1b[?25h');
-    } else {
-        sys.print('\x1b[?25l');
+    if (!quiet) {
+        if (show) {
+            sys.print('\x1b[?25h');
+        } else {
+            sys.print('\x1b[?25l');
+        }
     }
 }
 

--- a/bin/expresso
+++ b/bin/expresso
@@ -798,7 +798,7 @@ function report() {
     if (failures) {
         print('\n   [bold]{Failures}: [red]{' + failures + '}\n\n');
         notify('Failures: ' + failures);
-    } else {
+    } else if(!quiet) {
         if (serial) print('');
         print('\n   [green]{100%} ' + testcount + ' tests\n');
         notify('100% ok');


### PR DESCRIPTION
The quiet param is ignored when not also running tests with the -c param
