### PR TITLE
No cursor hiding in boring mode

### DIFF
--- a/bin/expresso
+++ b/bin/expresso
@@ -670,6 +670,7 @@ function run(files) {
  */
 
 function cursor(show) {
+    if (boring) return;    
     if (show) {
         sys.print('\x1b[?25h');
     } else {


### PR DESCRIPTION
When using the expresso's output by further tools (e.g. generating logs on a buildserver), the cursor hiding's control commands confuses these tools. This patch disables coloring when boring (no color) mode is enabled.
