### PR TITLE
Add support for encoding option in assert.response

### DIFF
--- a/bin/expresso
+++ b/bin/expresso
@@ -404,7 +404,8 @@ assert.response = function(server, req, res, msg){
             method = req.method || 'GET',
             status = res.status || res.statusCode,
             data = req.data || req.body,
-            requestTimeout = req.timeout || 0;
+            requestTimeout = req.timeout || 0,
+            encoding = req.encoding || 'utf8';
 
         var request = client.request(method, req.url, req.headers);
 
@@ -427,7 +428,7 @@ assert.response = function(server, req, res, msg){
         if (data) request.write(data);
         request.on('response', function(response){
             response.body = '';
-            response.setEncoding('utf8');
+            response.setEncoding(encoding);
             response.on('data', function(chunk){ response.body += chunk; });
             response.on('end', function(){
                 if (timer) clearTimeout(timer);

--- a/docs/index.html
+++ b/docs/index.html
@@ -224,6 +224,7 @@ as well.</p>
 <li><em>method</em> HTTP method</li>
 <li><em>data</em> request body</li>
 <li><em>headers</em> headers object</li>
+<li><em>encoding</em> encoding type</li>
 </ul>
 
 


### PR DESCRIPTION
This is a small change that adds an additional option to assert.response for selecting the encoding type. As before, it defaults to utf8, but now it can be overridden to test binary files.
