### PR TITLE
if err.name is blank (not an Error instance), use sys.inspect

### DIFF
--- a/bin/expresso
+++ b/bin/expresso
@@ -735,7 +735,7 @@ function runFile(file, fn) {
 
 function error(suite, test, err) {
     ++failures;
-    var name = err.name,
+    var name = err.name || sys.inspect(err),
         stack = err.stack ? err.stack.replace(err.name, '') : '',
         label = test === 'uncaught'
             ? test


### PR DESCRIPTION
Sometimes something other than an Error object gets thrown. This patch will use sys.inspect to show what the err object is if err.name is missing (so you can see what it is instead of just seeing 'undefined').
