### PR TITLE
call process.setMaxListeners to prevent hitting the limit

### DIFF
--- a/bin/expresso
+++ b/bin/expresso
@@ -808,6 +808,8 @@ function runSuite(title, tests, fn) {
     var setup = tests.setup || function(fn){ fn(); };
     var teardown = tests.teardown || function(fn){ fn(); };
 
+    process.setMaxListeners(10 + process.listeners('beforeExit').length  + keys.length);
+
     // Iterate tests
     (function next(){
         if (keys.length) {


### PR DESCRIPTION
if enough tests are queued, node throws an error on process.on 'beforeExit':

<pre>
(node) warning: possible EventEmitter memory leak detected. 11 listeners added. Use emitter.setMaxListeners() to increase limit.
Trace:
    at EventEmitter.<anonymous> (events.js:126:17)
    at EventEmitter.<anonymous> (node.js:232:29)
    at /home/vincent/Documents/devel/test/node_modules/expresso/bin/expresso:816:41
    [snip]
</pre>


this patch simply increases said limit by the number of queued tests.
