### PR TITLE
-C flag for generating and reporting test coverage for all files in working directory

### DIFF
--- a/bin/expresso
+++ b/bin/expresso
@@ -100,7 +100,7 @@ var jsonFile;
  * Directory where instrumented JS code will be stored
  */
 
-var coverageDirectory = ".jscoverage"
+var coverageDirectory = ".jscoverage";
 
 /**
  * Usage documentation.


### PR DESCRIPTION
Hi, I recently started using expresso, and I specially liked the code coverage output feature. However, I was initially surprised by the `-c` flag behavior. (Instrument the code in `lib/`, save in `lib-cov/`, then unshift it to `require.paths`)

Since my project has code outside of the `lib` folder I would like to report the coverage, I had to manually run `node-jscoverage` and then run `expresso`. I considered making a script to automate this, but I thought that perhaps a new flag on expresso that did the work for me would be a nice addition.

**What this code does:**

When the `-C` (or `--cwd-coverage`) flag is supplied, expresso will create a temporary folder and run `node-jscoverage` with the working directory as a source and the temporary folder created as a destination.

It then will move the temporary folder with the instrumented code to a hidden `.jscoverage/` directory, nested in the working directory, `chdir` into it and run the specified tests there.

It's smart enough not to regenerate the instrumented code if no files were changed (it does that by checking the last modified dates), allowing users to run individual test cases without having to wait for `node-jscoverage` to run again.
