### PR TITLE
fix serial bug

### DIFF
--- a/bin/expresso
+++ b/bin/expresso
@@ -777,6 +777,8 @@ function runFile(file, fn) {
                setTimeout(check, 20);
            }
         })();
+    } else if(serial) {
+        fn();
     }
 }
 


### PR DESCRIPTION
when files in the test directory do not match the pattern serial mode
stops because runFile callback is not run
