### PR TITLE
Bug Fix for Issue # 95 - assert.response hangs when assertion fails

### DIFF
--- a/bin/expresso
+++ b/bin/expresso
@@ -473,23 +473,37 @@ assert.response = function(server, req, res, msg){
                     var eql = res.body instanceof RegExp
                       ? res.body.test(response.body)
                       : res.body === response.body;
-                    assert.ok(
-                        eql,
-                        msg + 'Invalid response body.\n'
-                            + '    Expected: ' + sys.inspect(res.body) + '\n'
-                            + '    Got: ' + sys.inspect(response.body)
-                    );
+                    try {
+                        assert.ok(
+                            eql,
+                            msg + colorize('Invalid response body.\n'
+                                + '    Expected: [green]{' + sys.inspect(res.body) + '}\n'
+                                + '    Got: [red]{' + sys.inspect(response.body) + '}')
+                        );
+                    }
+                    catch(err)
+                    {
+                        check();
+                        assert.ok(false, err.message);
+                     }
                 }
 
                 // Assert response status
                 if (typeof status === 'number') {
-                    assert.equal(
-                        response.statusCode,
-                        status,
-                        msg + colorize('Invalid response status code.\n'
-                            + '    Expected: [green]{' + status + '}\n'
-                            + '    Got: [red]{' + response.statusCode + '}')
-                    );
+                    try {
+                        assert.equal(
+                            response.statusCode,
+                            status,
+                            msg + colorize('Invalid response status code.\n'
+                                + '    Expected: [green]{' + status + '}\n'
+                                + '    Got: [red]{' + response.statusCode + '}')
+                        );
+                    }
+                    catch(err)
+                    {
+                        check();
+                        assert.ok(false, err.message);
+                    }
                 }
 
                 // Assert response headers
@@ -502,12 +516,19 @@ assert.response = function(server, req, res, msg){
                             eql = expected instanceof RegExp
                               ? expected.test(actual)
                               : expected == actual;
-                        assert.ok(
-                            eql,
-                            msg + colorize('Invalid response header [bold]{' + name + '}.\n'
-                                + '    Expected: [green]{' + expected + '}\n'
-                                + '    Got: [red]{' + actual + '}')
-                        );
+                        try {
+                            assert.ok(
+                                eql,
+                                msg + colorize('Invalid response header [bold]{' + name + '}.\n'
+                                    + '    Expected: [green]{' + expected + '}\n'
+                                    + '    Got: [red]{' + actual + '}')
+                            );
+                        }
+                        catch(err)
+                        {
+                            check();
+                            assert.ok(false, err.message);
+                        }
                     }
                 }
 


### PR DESCRIPTION
This issue occurs based on the assertion library taking over and throwing an exception when it's base assertions fail, this unfortunately means as soon as a failure occurs no further code executes in expresso after that specific assertion.   

I've added try/catch blocks to catch the error assert throws and then call the check() method before issuing an assert.ok(false, err.message) which will of course cause the exception to then be re-thrown.

I've also added colorize where missing in the affected code blocks.
