### PR TITLE
explicit process.exit for serial-mode

### DIFF
--- a/bin/expresso
+++ b/bin/expresso
@@ -750,6 +750,8 @@ function runFiles(files) {
         (function next(){
             if (files.length) {
                 runFile(files.shift(), next);
+            } else {
+              process.exit(0);
             }
         })();
     } else {


### PR DESCRIPTION
With mongoose, expresso doesn't exit. Make expresso exit after serial-mode test execution.
