### PR TITLE
Fixes having to hit CTRL + C when doing serial tests with Socket.io

### DIFF
--- a/bin/expresso
+++ b/bin/expresso
@@ -792,9 +792,9 @@ function runFiles(files) {
             if (files.length) {
                 runFile(files.shift(), next);
             } else {
-                setTimeout(function() {
+                process.nextTick(function() {
                     process.exit(0);
-                }, 0);
+                });
             }
         })();
     } else {


### PR DESCRIPTION
I was doing some tests using Socket.io and even though everything ran okay except that I had to manually exit Expresso using ctrl + c.

I tried using `process.exit` inside the `else` block but that would cause Expresso to output `Failure: Only 1 of 3 suites have been started`. Using a timeout seems to fix it despite the fact that I'm using 0 as time. Not really sure how this works, but it does :)

_Edit:_ The first answer of ["Why does setTimeout(fn, 0) sometimes help?"](http://stackoverflow.com/questions/779379/why-does-settimeoutfn-0-sometimes-help/779785#779785) provides a good explanation.

BTW, this it my first push request, I hope it helps.
