### PR TITLE
Running all tests in a suite before reporting

### DIFF
--- a/bin/expresso
+++ b/bin/expresso
@@ -381,7 +381,7 @@ assert.length = function(val, n, msg) {
  * @param {String} msg
  */
 assert.response = function(server, req, res, msg) {
-    var test = assert._test;
+    var test = this._test;
 
     // Callback as third or fourth arg
     var callback = typeof res === 'function'


### PR DESCRIPTION
These changes run all the tests in a suite before reporting. Previous the first assertion failure was reported and expresso stopped running tests. I believe it is more useful to report all the failures in the test, to prevent the developer from executing the run/fix loop many times.
