### PR TITLE
consistency issue between serial and paralel tests

### DIFF
--- a/bin/expresso
+++ b/bin/expresso
@@ -952,7 +952,7 @@ Test.prototype.runSerial = function(callback) {
                     test.report();
                 });
             };
-            test.fn(test.callback);
+            test.fn(test.callback, test.assert);
         }
     });
 };


### PR DESCRIPTION
if you try to run serialy tests that were originally written for parallel - you get 'undefined' for the named assert argument. this change is required for consistency between writing serial and paralel tests the same way
