### PR TITLE
Disable cursor handling on windows

### DIFF
--- a/bin/expresso
+++ b/bin/expresso
@@ -1040,14 +1040,14 @@ process.on('uncaughtException', function(err) {
     }
 });
 
-// Show cursor
-
-['INT', 'TERM', 'QUIT'].forEach(function(sig) {
-    process.on('SIG' + sig, function() {
-        cursor(true);
-        process.exit(1);
+// Show cursor - for nonwindows
+if (process.platform.substr(0,3) !== 'win')
+    ['INT', 'TERM', 'QUIT'].forEach(function(sig) {
+        process.on('SIG' + sig, function() {
+            cursor(true);
+            process.exit(1);
+        });
     });
-});
 
 // Report test coverage when available
 // and emit "beforeExit" event to perform


### PR DESCRIPTION
Disable cursor handling on windows.
No need - it runs well without
