### PR TITLE
Fixing --serial command. TODO added

### DIFF
--- a/bin/expresso
+++ b/bin/expresso
@@ -970,7 +970,12 @@ Test.prototype.runSerial = function(callback) {
                     test.report();
                 });
             };
-            test.fn(test.callback);
+
+            // @TODO: test MUST call beforeExit function in order to iterate to next test.
+            // tested on node v.10.20.
+            // If you will not call beforeExit -> then will receive 'test timed out' error.
+            //
+            test.fn(test.callback,test.assert);
         }
     });
 };


### PR DESCRIPTION
When running tests with --serial parameter -> causes error because assert object is NULL.

Also i've found 2nd bug with --serial execution.
In case test is not calling 'beforeExit' -> test would always fail with "test timed out" error. I haven't fixed that yet, but wrote comment.  
